### PR TITLE
Added dependency for 'screenshot-basic'

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -22,3 +22,5 @@ server_scripts {
 
 	"server/dist/index.js",
 }
+
+dependency 'screenshot-basic'


### PR DESCRIPTION
Will start 'screenshot-basic' resource before fivemanage_lib