### PR TITLE
tweak takeServerImage with timeout.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 
 # fivem specific
 .yarn.installed
+.idea

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ exports.fmsdk
 **Function Definition:**
 
 ```typescript
-takeServerImage(playerSource: string | number, metadata?: Record<string, unknown>): Promise<{ url: string }>
+takeServerImage(playerSource: string | number, metadata?: Record<string, unknown>, timeout?: number): Promise<{ url: string }>
 ```
 
 **Lua Example:**
@@ -109,6 +109,21 @@ local imageData = exports.fmsdk:takeServerImage(playerSource, {
 })
 
 print(imageData.url)
+
+
+-- With metadata and timeout support.
+local success, imageData = pcall(function()
+    return exports.fmsdk:takeServerImage(source, {
+        name = 'My image',
+        description = 'This is my image',
+    }, 10000)
+end)
+
+if success then
+    print(imageData.url)
+else
+    error('we are unable to capture screenshot to player.')
+end
 ```
 
 **JavaScript Example:**

--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
 		"appendPlayerIdentifiers": true,
 		"excludedPlayerIdentifiers": ["ip"],
 		"playerEvents": true,
-		"chatEvents": true
+		"chatEvents": true,
+		"baseEvents": true
 	}
 }


### PR DESCRIPTION
Hello,

I am proposing this modification, which could be highly useful for many people.

During my use of the library, I noticed that when the NUI experiences lag, or simply when screenshot-basic doesn't function for one reason or another, it blocks the rest of the code (which is understandable). However,

In scenarios where, during a sensitive event for example, we want to take a screenshot of the player and then ban or kick them from the server it becomes important to have a precautionary timeout in case the NUI or screenshot-basic isn't working properly.

I hope I'm proceeding correctly with this pull request; it's my first time!