### PR TITLE
feat(server): Presigned url export

### DIFF
--- a/features/boot/server/bootstrap.ts
+++ b/features/boot/server/bootstrap.ts
@@ -1,6 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { startImageFeature } from "~/images/server/main";
 import { startLogsFeature } from "~/logs/server/logger";
+import { startPresignedFeature } from "~/presigned/server/main";
 
 declare global {
 	// biome-ignore lint: expected var
@@ -12,6 +13,7 @@ globalThis.serverSessionId = createId();
 function boot() {
 	startImageFeature();
 	startLogsFeature();
+	startPresignedFeature();
 }
 
 boot();

--- a/features/presigned/server/main.ts
+++ b/features/presigned/server/main.ts
@@ -1,0 +1,46 @@
+import { object, parse, string, url, picklist } from "valibot"
+import { convars } from "~/utils/server/convars"
+import fetch from 'node-fetch'
+
+const apiUrl = 'https://api.fivemanage.com/api/presigned-url'
+
+
+const PresignedRequestSchema = picklist(['image', 'audio' ,'video'], 'File type must be one of "image", "audio" or "video"')
+
+type PresignedResponse = {
+	presignedUrl: string
+}
+
+const PresignedResponseSchema = object(
+	{
+		presignedUrl: string('Image URL must be a string', [url('Image URL must be a valid URL')]),
+	},
+	'Presigned response is malformed'
+)
+
+async function requestPresignedUrl(fileType: string): Promise<PresignedResponse['presignedUrl']> {
+    const parsedFileType = parse(PresignedRequestSchema, fileType)
+
+	const res = await fetch(`${apiUrl}?fileType=${parsedFileType}`, {
+		method: 'GET',
+		headers: {
+			Authorization: convars.FIVEMANAGE_MEDIA_API_KEY,
+		},
+	})
+
+	if (res.ok === false) {
+		throw new Error('Failed to request presigned url')
+	}
+
+	const { presignedUrl } = parse(PresignedResponseSchema, await res.json())
+
+	return presignedUrl
+}
+
+function registerExports() {
+    exports('requestPresignedUrl', requestPresignedUrl)
+}
+
+export function startPresignedFeature() {
+    registerExports();
+}

--- a/features/presigned/server/main.ts
+++ b/features/presigned/server/main.ts
@@ -2,8 +2,7 @@ import { object, parse, string, url, picklist } from "valibot"
 import { convars } from "~/utils/server/convars"
 import fetch from 'node-fetch'
 
-const apiUrl = 'https://api.fivemanage.com/api/presigned-url'
-
+const API_URL = 'https://api.fivemanage.com/api/presigned-url'
 
 const PresignedRequestSchema = picklist(['image', 'audio' ,'video'], 'File type must be one of "image", "audio" or "video"')
 
@@ -21,16 +20,14 @@ const PresignedResponseSchema = object(
 async function requestPresignedUrl(fileType: string): Promise<PresignedResponse['presignedUrl']> {
     const parsedFileType = parse(PresignedRequestSchema, fileType)
 
-	const res = await fetch(`${apiUrl}?fileType=${parsedFileType}`, {
+	const res = await fetch(`${API_URL}?fileType=${parsedFileType}`, {
 		method: 'GET',
 		headers: {
 			Authorization: convars.FIVEMANAGE_MEDIA_API_KEY,
 		},
 	})
 
-	if (res.ok === false) {
-		throw new Error('Failed to request presigned url')
-	}
+	if (!res.ok) throw new Error('Failed to request presigned url');
 
 	const { presignedUrl } = parse(PresignedResponseSchema, await res.json())
 


### PR DESCRIPTION
With the introduction of pre signed urls I believe an export is convenient