### PR TITLE
Add excludeInDepthMetadata option to logging config

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
 		"enableCloudLogging": true,
 		"appendPlayerIdentifiers": true,
 		"excludedPlayerIdentifiers": ["ip"],
+		"excludeInDepthMetadata": false,
 		"playerEvents": false,
 		"chatEvents": false,
 		"baseEvents": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -60,6 +60,11 @@
 					},
 					"default": []
 				},
+				"excludeInDepthMetadata": {
+					"description": "Remove in-depth metadata such as server session ID from logs.",
+					"type": "boolean",
+					"default": false
+				},
 				"playerEvents": {
 					"description": "Enable player events like connecting and dropped.",
 					"type": "boolean",

--- a/features/logs/server/logger.ts
+++ b/features/logs/server/logger.ts
@@ -69,8 +69,7 @@ export function log(level: string, message: string, metadata: LogMetadata = {}, 
 
 		const meta: LogMetadata = {
 			...metadata,
-			_resourceName: GetInvokingResource(),
-			_serverSessionId: globalThis.serverSessionId,
+			serverSessionId: config.logs.excludeInDepthMetadata ? null : globalThis.serverSessionId,
 		};
 
 		if (config.logs.appendPlayerIdentifiers) {
@@ -87,8 +86,14 @@ export function log(level: string, message: string, metadata: LogMetadata = {}, 
 			}
 		}
 
+		let resourceName = GetInvokingResource();
+		if (!resourceName) {
+			resourceName = "Unknown Resource";
+			console.warn("Could not identify the invoking resource for this log message. This usually happens when the log export is called from a cross-network event (e.g., Server ↔ Client). This will NOT affect the log, however it will just show the resource as 'Unknown Resource'.");
+		}
+
 		logger.log(level, message, {
-			resource: _internalOpts?._internal_RESOURCE ?? meta._resourceName,
+			resource: _internalOpts?._internal_RESOURCE ?? resourceName,
 			metadata: meta,
 			datasetId: "default",
 		});

--- a/features/utils/common/config.ts
+++ b/features/utils/common/config.ts
@@ -18,6 +18,7 @@ const ConfigSchema = object({
 		enableCloudLogging: boolean(),
 		appendPlayerIdentifiers: boolean(),
 		excludedPlayerIdentifiers: array(string([minLength(1)])),
+		excludeInDepthMetadata: boolean(),
 		playerEvents: boolean(),
 		baseEvents: boolean(),
 		chatEvents: boolean(),


### PR DESCRIPTION
Introduces the 'excludeInDepthMetadata' Boolean to config and schema, allowing removal of in-depth metadata such as server session ID from logs. Logger implementation updated to respect this option and improve resource name handling when unavailable and removing it showing double.

I have attempted to remove the Resource all together however its embedded into Winston and that goes into the backend so I did not attempt it. It would be stupid of me to push or attempt that without seeing what is on the backend to make sure I do not cause an error.