### PR TITLE
Refactoring of Logging and Ingesting, and adding a flag for the User to remove the SessionId variable.

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,6 +7,7 @@
 		"enableCloudLogging": true,
 		"appendPlayerIdentifiers": true,
 		"excludedPlayerIdentifiers": ["ip"],
+		"excludeInDepthMetadata": false,
 		"playerEvents": false,
 		"chatEvents": false,
 		"baseEvents": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -60,6 +60,11 @@
 					},
 					"default": []
 				},
+				"excludeInDepthMetadata": {
+					"description": "Remove in-depth metadata such as server session ID from logs.",
+					"type": "boolean",
+					"default": false
+				},
 				"playerEvents": {
 					"description": "Enable player events like connecting and dropped.",
 					"type": "boolean",

--- a/features/logs/server/logger.ts
+++ b/features/logs/server/logger.ts
@@ -69,8 +69,7 @@ export function log(level: string, message: string, metadata: LogMetadata = {}, 
 
 		const meta: LogMetadata = {
 			...metadata,
-			_resourceName: GetInvokingResource(),
-			_serverSessionId: globalThis.serverSessionId,
+			serverSessionId: config.logs.excludeInDepthMetadata ? null : globalThis.serverSessionId,
 		};
 
 		if (config.logs.appendPlayerIdentifiers) {
@@ -87,8 +86,14 @@ export function log(level: string, message: string, metadata: LogMetadata = {}, 
 			}
 		}
 
+		let resourceName = GetInvokingResource();
+		if (!resourceName) {
+			resourceName = "Unknown Resource";
+			console.warn("Could not identify the invoking resource for this log message. This usually happens when the log export is called from a cross-network event (e.g., Server ↔ Client). This will NOT affect the log, however it will just show the resource as 'Unknown Resource'.");
+		}
+
 		logger.log(level, message, {
-			resource: _internalOpts?._internal_RESOURCE ?? meta._resourceName,
+			resource: _internalOpts?._internal_RESOURCE ?? resourceName,
 			metadata: meta,
 			datasetId: "default",
 		});

--- a/features/logs/server/logger.ts
+++ b/features/logs/server/logger.ts
@@ -63,96 +63,60 @@ const LogSchema = object({
 	metadata: record(unknown()),
 });
 
-export function log(level: string, message: string, metadata: LogMetadata = {}, _internalOpts?: _InternalOptions) {
+function processMetadata(metadata: LogMetadata): LogMetadata {
+	const meta: LogMetadata = { ...metadata };
+
+	if (config.logs.appendPlayerIdentifiers) {
+		if (meta.playerSource) {
+			meta._playerIdentifiers = getFormattedPlayerIdentifiers(meta.playerSource);
+		}
+		if (meta.targetSource) {
+			meta._targetIdentifiers = getFormattedPlayerIdentifiers(meta.targetSource);
+		}
+	}
+
+	return meta;
+}
+
+function executeLog(level: string, message: string, metadata: LogMetadata, datasetId: string, _internalOpts?: _InternalOptions) {
 	try {
 		parse(LogSchema, { level, message, metadata });
 
-		const meta: LogMetadata = {
-			...metadata,
-			serverSessionId: config.logs.excludeInDepthMetadata ? null : globalThis.serverSessionId,
-		};
+		const meta = processMetadata(metadata);
+		const resourceName = GetInvokingResource() || "Unknown Resource";
 
-		if (config.logs.appendPlayerIdentifiers) {
-			if (meta.playerSource) {
-				meta._playerIdentifiers = getFormattedPlayerIdentifiers(
-					meta.playerSource,
-				);
-			}
-
-			if (meta.targetSource) {
-				meta._targetIdentifiers = getFormattedPlayerIdentifiers(
-					meta.targetSource,
-				);
-			}
-		}
-
-		let resourceName = GetInvokingResource();
-		if (!resourceName) {
-			resourceName = "Unknown Resource";
+		if (!GetInvokingResource()) {
 			console.warn("Could not identify the invoking resource for this log message. This usually happens when the log export is called from a cross-network event (e.g., Server ↔ Client). This will NOT affect the log, however it will just show the resource as 'Unknown Resource'.");
 		}
 
 		logger.log(level, message, {
 			resource: _internalOpts?._internal_RESOURCE ?? resourceName,
 			metadata: meta,
-			datasetId: "default",
+			datasetId,
 		});
 	} catch (error) {
 		if (error instanceof ValiError) {
-			console.error(
-				"Invalid log params:\n",
-				flatten<typeof LogSchema>(error).nested,
-			);
-
+			console.error("Invalid log params:\n", flatten<typeof LogSchema>(error).nested);
 			return;
 		}
-
 		console.error("Error executing log", error);
 	}
 }
 
-// this new function is used to ingest logs to a specific dataset
+export function log(level: string, message: string, metadata: LogMetadata = {}, _internalOpts?: _InternalOptions) {
+	const meta = {
+		...metadata,
+		serverSessionId: config.logs.excludeInDepthMetadata ? null : globalThis.serverSessionId,
+	};
+	executeLog(level, message, meta, "default", _internalOpts);
+}
+
 export function ingest(datasetId: string, level: string, message: string, metadata: LogMetadata = {}, _internalOpts?: _InternalOptions) {
-	try {
-		parse(LogSchema, { level, message, metadata });
-
-		const meta: LogMetadata = {
-			...metadata,
-			_resourceName: GetInvokingResource(),
-			_serverSessionId: globalThis.serverSessionId,
-		};
-
-		if (config.logs.appendPlayerIdentifiers) {
-			if (meta.playerSource) {
-				meta._playerIdentifiers = getFormattedPlayerIdentifiers(
-					meta.playerSource,
-				);
-			}
-
-			if (meta.targetSource) {
-				meta._targetIdentifiers = getFormattedPlayerIdentifiers(
-					meta.targetSource,
-				);
-			}
-		}
-
-		logger.log(level, message, {
-			resource: _internalOpts?._internal_RESOURCE ?? meta._resourceName,
-			metadata: meta,
-			datasetId: datasetId,
-		});
-	} catch (error) {
-		if (error instanceof ValiError) {
-			console.error(
-				"Invalid log params:\n",
-				flatten<typeof LogSchema>(error).nested,
-			);
-
-			return;
-		}
-
-		console.error("Error executing log", error);
-	}
+	const meta = {
+		...metadata,
+		serverSessionId: config.logs.excludeInDepthMetadata ? null : globalThis.serverSessionId,
+	};
+	executeLog(level, message, meta, datasetId, _internalOpts);
 }
 
 export function info(datasetId: string, message: string, metadata: LogMetadata = {}, _internalOpts?: _InternalOptions) {

--- a/features/utils/common/config.ts
+++ b/features/utils/common/config.ts
@@ -18,6 +18,7 @@ const ConfigSchema = object({
 		enableCloudLogging: boolean(),
 		appendPlayerIdentifiers: boolean(),
 		excludedPlayerIdentifiers: array(string([minLength(1)])),
+		excludeInDepthMetadata: boolean(),
 		playerEvents: boolean(),
 		baseEvents: boolean(),
 		chatEvents: boolean(),


### PR DESCRIPTION
This pull request adds a new configuration option to control the inclusion of in-depth metadata in logs, such as the server session ID. The main change is the introduction of the `excludeInDepthMetadata` flag, which allows you to remove the Server Session Id from logs and in the future any other things that may get added. The logging functions have been refactored to respect this new setting and to improve code clarity.

Logging logic updates:
* Refactored the logging functions in `features/logs/server/logger.ts` to check the `excludeInDepthMetadata` flag and conditionally include or exclude the server session ID in log metadata.
* Improved code structure by separating metadata processing and log execution, and added a warning when the invoking resource cannot be identified.